### PR TITLE
Add latest reviews intent

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ const SKILL_NAME = 'The Guardian';
 const getHeadlines = require('./intentLogic/getHeadlines');
 const getOpinion = require('./intentLogic/getOpinion');
 const getReview = require('./intentLogic/getReview');
+const getLatestReviews = require('./intentLogic/getLatestReviews');
 const readContentAtPosition = require('./intentLogic/readContentAtPosition');
 const yes = require('./intentLogic/yes');
 
@@ -57,6 +58,16 @@ var handlers = {
     'GetOpinionIntent': getOpinion,
 
     'GetReviewIntent': getReview,
+
+    'GetLatestReviewsIntent': getLatestReviews,
+
+    'ReviewTypeIntent': function() {
+        const slots = this.event.request.intent.slots;
+        if (slots.review_type && slots.review_type.value) {
+            this.event.session.attributes.reviewType = slots.review_type.value;
+            this.emit(this.event.session.attributes.lastIntent)
+        }
+    },
 
     'AMAZON.HelpIntent': function() {
         this.event.session.attributes.lastIntent = 'Help'

--- a/src/index.js
+++ b/src/index.js
@@ -61,6 +61,7 @@ var handlers = {
 
     'GetLatestReviewsIntent': getLatestReviews,
 
+    //The user has specified a review_type. The reviews intents will prompt for one if missing.
     'ReviewTypeIntent': function() {
         const slots = this.event.request.intent.slots;
         if (slots.review_type && slots.review_type.value) {

--- a/src/intentLogic/getLatestReviews.js
+++ b/src/intentLogic/getLatestReviews.js
@@ -1,0 +1,86 @@
+const get = require('simple-get-promise').get;
+const asJson = require('simple-get-promise').asJson;
+
+const helpers = require('../helpers');
+const speech = require('../speech').speech;
+const sound = require('../speech').sound;
+const getMoreOffset = require('../helpers').getMoreOffset;
+
+module.exports = function(isNewIntentFlag) {
+    const isNewIntent = isNewIntentFlag !== false;
+
+    const attributes = this.event.session.attributes;
+    const slots = this.event.request.intent.slots;
+
+    attributes.lastIntent = 'GetLatestReviewsIntent';
+
+    if (isNewIntent) attributes.reviewType = slots.review_type.value;
+
+    if (attributes.reviewType) {
+        attributes.moreOffset = getMoreOffset(isNewIntent, attributes.moreOffset);
+
+        const filter = "page="+ ((attributes.moreOffset / helpers.pageSize) + 1)
+                     + "&page-size="+ helpers.pageSize
+                     + "&tag=tone/reviews,"+ getTagType(attributes.reviewType)
+                     + "&show-fields=standfirst,byline,headline&show-blocks=all";
+
+        const capiQuery = helpers.capiQuery('search', filter);
+        get(capiQuery)
+            .then(asJson)
+            .then(json => {
+                if (json.response.results && json.response.results.length > 1) {
+                    attributes.positionalContent = json.response.results.map(review => review.id);
+                    const preamble = getPreamble(isNewIntent, json.response.results.length, attributes.reviewType);
+                    const reviews = json.response.results.map(review => {
+                        return review.fields.headline + sound.transition;
+                    });
+                    const conclusion = getConclusion(json.response.results.length);
+
+                    this.emit(':ask', `${preamble} ${reviews} ${conclusion}`);
+                } else {
+                    this.emit(':tell', speech.reviews.notfound);
+                }
+            })
+            .catch(error => {
+                this.emit(':tell', speech.reviews.notfound);
+            })
+    } else {
+        this.emit(':ask', speech.reviews.clarifyType);
+    }
+}
+
+function getTagType(reviewType) {
+    switch (reviewType) {
+        case 'film':
+            return 'film/film';
+            break;
+        case 'restaurant':
+            return 'lifeandstyle/restaurants';
+            break;
+        case 'book':
+            return 'books/books';
+            break;
+        case 'music':
+            return 'music/music';
+            break;
+    }
+}
+
+function getPreamble(isNewIntent, reviewCount, reviewType) {
+    if (isNewIntent) {
+        return `Here are the latest ${reviewType} reviews.`;
+    } else {
+        if (reviewCount === 1) {
+            return `The next ${reviewType} review is`;
+        } else {
+            return `The next ${reviewType} reviews are`;
+        }
+    }
+}
+
+function getConclusion(reviewCount) {
+    if (reviewCount == 1) return speech.reviews.followup1;
+    if (reviewCount == 2) return speech.reviews.followup2;
+    return speech.reviews.followup3
+}
+

--- a/src/intentLogic/getLatestReviews.js
+++ b/src/intentLogic/getLatestReviews.js
@@ -19,12 +19,7 @@ module.exports = function(isNewIntentFlag) {
     if (attributes.reviewType) {
         attributes.moreOffset = getMoreOffset(isNewIntent, attributes.moreOffset);
 
-        const filter = "page="+ ((attributes.moreOffset / helpers.pageSize) + 1)
-                     + "&page-size="+ helpers.pageSize
-                     + "&tag=tone/reviews,"+ getTagType(attributes.reviewType)
-                     + "&show-fields=standfirst,byline,headline&show-blocks=all";
-
-        const capiQuery = helpers.capiQuery('search', filter);
+        const capiQuery = getCapiQuery(attributes.moreOffset, attributes.reviewType);
         get(capiQuery)
             .then(asJson)
             .then(json => {
@@ -49,6 +44,15 @@ module.exports = function(isNewIntentFlag) {
     }
 }
 
+function getCapiQuery(offset, reviewType) {
+    const filter = "page="+ ((offset / helpers.pageSize) + 1)
+                 + "&page-size="+ helpers.pageSize
+                 + "&tag=tone/reviews,"+ getTagType(reviewType)
+                 + "&show-fields=standfirst,byline,headline&show-blocks=all";
+
+    return helpers.capiQuery('search', filter);
+}
+
 function getTagType(reviewType) {
     switch (reviewType) {
         case 'film':
@@ -67,15 +71,9 @@ function getTagType(reviewType) {
 }
 
 function getPreamble(isNewIntent, reviewCount, reviewType) {
-    if (isNewIntent) {
-        return `Here are the latest ${reviewType} reviews.`;
-    } else {
-        if (reviewCount === 1) {
-            return `The next ${reviewType} review is`;
-        } else {
-            return `The next ${reviewType} reviews are`;
-        }
-    }
+    if (isNewIntent) return `Here are the latest ${reviewType} reviews.`;
+    if (reviewCount === 1) return `The next ${reviewType} review is`;
+    return `The next ${reviewType} reviews are`;
 }
 
 function getConclusion(reviewCount) {

--- a/src/intentLogic/getReview.js
+++ b/src/intentLogic/getReview.js
@@ -10,7 +10,7 @@ module.exports = function () {
     this.event.session.attributes.lastIntent = 'GetReviewIntent';
 
     const slots = this.event.request.intent.slots;
-    const reviewType = slots.review_types.value
+    const reviewType = slots.review_type.value
     const searchTerm = slots.search_term.value
 
     var counter = this.event.session.attributes.reviewsRead ? this.event.session.attributes.reviewsRead : 0

--- a/src/speech.js
+++ b/src/speech.js
@@ -50,11 +50,14 @@ const speech = {
         more: 'the next three reviews are:',
         question: 'Would you like me to read the first, second or third review or would you like more {0} reviews?',
         hearAgain: 'OK. Would you like hear the choices again or more reviews?',
-        notfound: 'Sorry, I could not find you a review for you. Is there anything else I can help with?',
-        clarifyType: 'Is it a restaurant, book, film, music review your after?',
+        notfound: 'Sorry, I could not find a review for you. Is there anything else I can help with?',
+        clarifyType: 'Is it a restaurant, book, film, or music review you\'re after?',
         clarifySearch: 'What would you like a {0} review for?',
         reprompt: 'Would you like to hear another review?',
-        explainer: 'I have some great reviews for films, books, music and restaurants. Just say: give me the latest restaurant reviews. If you have a specific title in mind - simply ask: give me a film review for x. ' 
+        explainer: 'I have some great reviews for films, books, music and restaurants. Just say: give me the latest restaurant reviews. If you have a specific title in mind - simply ask: give me a film review for x. ',
+        followup1: 'Would you like me to read this review?',
+        followup2: 'Would you like me to read the first review or the second review?',
+        followup3: 'Would you like me to read the first, second or third review or would you like more reviews?'
     },
     help: {
         explainer: 'Happy to help. With The Guardian skill you can ask for the news, reviews, sports headlines and football scores. In News, you can ask for more headlines or get stories by topic and author. In Reviews, we have some great reviews for films, books, music and restaurants. You can ask for latest reviews and best by type or for a specific title. In Sport, you can ask for the headlines for football, cricket, rugby, tennis, F1, cycling or golf. Additionally for football, you can ask for the live scores, latest scores or fixtures. ',

--- a/test/fixtures/getLatestReviews.json
+++ b/test/fixtures/getLatestReviews.json
@@ -1,0 +1,29 @@
+{
+  "session": {
+    "sessionId": "",
+    "application": {
+      "applicationId": ""
+    },
+    "attributes": {},
+    "user": {
+      "userId": ""
+    },
+    "new": true
+  },
+  "request": {
+    "type": "IntentRequest",
+    "requestId": "",
+    "locale": "en-GB",
+    "timestamp": "2016-08-30T16:12:35Z",
+    "intent": {
+      "name": "GetLatestReviewsIntent",
+      "slots": {
+        "review_type": {
+          "name": "review_type",
+          "value": "film"
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/test/fixtures/getReview.json
+++ b/test/fixtures/getReview.json
@@ -19,8 +19,8 @@
 		"intent": {
 			"name": "GetReviewIntent",
 			"slots": {
-				"review_types": {
-					"name": "review_types",
+				"review_type": {
+					"name": "review_type",
 					"value": "book"
 				},
 				"search_term": {

--- a/test/fixtures/moreAfterLatestReviews.json
+++ b/test/fixtures/moreAfterLatestReviews.json
@@ -1,0 +1,29 @@
+{
+  "session": {
+    "sessionId": "",
+    "application": {
+      "applicationId": ""
+    },
+    "attributes": {
+        "moreOffset": 0,
+        "lastIntent": "GetLatestReviewsIntent",
+        "reviewType": "film"
+    },
+    "user": {
+      "userId": ""
+    },
+    "new": true
+  },
+  "request": {
+    "type": "IntentRequest",
+    "requestId": "",
+    "locale": "en-GB",
+    "timestamp": "2016-08-30T16:12:35Z",
+    "intent": {
+      "name": "MoreIntent",
+      "slots": {
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/test/fixtures/reviewTypeAfterLatestReviews.json
+++ b/test/fixtures/reviewTypeAfterLatestReviews.json
@@ -1,0 +1,31 @@
+{
+  "session": {
+    "sessionId": "",
+    "application": {
+      "applicationId": ""
+    },
+    "attributes": {
+        "lastIntent": "GetLatestReviewsIntent"
+    },
+    "user": {
+      "userId": ""
+    },
+    "new": true
+  },
+  "request": {
+    "type": "IntentRequest",
+    "requestId": "",
+    "locale": "en-GB",
+    "timestamp": "2016-08-31T09:44:11Z",
+    "intent": {
+      "name": "ReviewTypeIntent",
+      "slots": {
+        "review_type": {
+          "name": "review_type",
+          "value": "film"
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/test/fixtures/yes.json
+++ b/test/fixtures/yes.json
@@ -19,8 +19,8 @@
 		"intent": {
 			"name": "GetReviewIntent",
 			"slots": {
-				"review_types": {
-					"name": "review_types",
+				"review_type": {
+					"name": "review_type",
 					"value": "book"
 				},
 				"search_term": {

--- a/test/index.js
+++ b/test/index.js
@@ -5,11 +5,14 @@ const headLineSectionJson = require('./fixtures/getHeadlinesForSection.json');
 const opinionJson = require('./fixtures/getOpinionOn.json');
 const inexistentOpinionJson = require('./fixtures/getInexistentOpinion.json');
 const reviewJson = require('./fixtures/getReview.json');
+const latestReviewsJson = require('./fixtures/getLatestReviews.json');
 const posAfterHeadJson = require('./fixtures/positionalContentAfterHeadlines.json');
 const moreAfterHeadlines = require('./fixtures/moreAfterHeadlines.json');
 const moreAfterTechHeadlines = require('./fixtures/moreAfterTechHeadlines.json');
 const moreAfterBrexitOpinion = require('./fixtures/moreAfterBrexitOpinions.json');
 const localizedHeadlines = require('./fixtures/getLocalizedHeadlines.json');
+const moreAfterLatestReviews = require('./fixtures/moreAfterLatestReviews.json');
+const reviewTypeAfterLatestReviews = require('./fixtures/reviewTypeAfterLatestReviews.json');
 
 const speech = require('../src/speech').speech;
 
@@ -141,6 +144,57 @@ tap.test('Test the get {type} review on {something} intent', test => {
                     test.fail()
                 }
             });
+    }
+);
+
+tap.test('Test get latest reviews intent', test => {
+    test.plan(3);
+    lambda(
+        latestReviewsJson, {
+            succeed: function (response) {
+                test.equal(response.sessionAttributes.lastIntent, "GetLatestReviewsIntent");
+                test.equal(response.sessionAttributes.positionalContent.length, 3);
+                test.ok(response.response.outputSpeech.ssml.indexOf('break time') != -1);
+                test.end()
+            },
+            fail: function (error) {
+                test.fail()
+            }
+        });
+    }
+);
+
+tap.test('Test get more reviews after latest reviews intent', test => {
+    test.plan(3);
+    lambda(
+        moreAfterLatestReviews, {
+            succeed: function (response) {
+                test.equal(response.sessionAttributes.moreOffset, 3);
+                test.equal(response.sessionAttributes.reviewType, 'film');
+                test.equal(response.sessionAttributes.lastIntent, "GetLatestReviewsIntent");
+                test.end()
+            },
+            fail: function (error) {
+                test.fail()
+            }
+        });
+    }
+);
+
+tap.test('Test review_type after get latest reviews intent', test => {
+    test.plan(3);
+    lambda(
+        reviewTypeAfterLatestReviews, {
+            succeed: function (response) {
+                test.equal(response.sessionAttributes.lastIntent, "GetLatestReviewsIntent");
+                test.equal(response.sessionAttributes.positionalContent.length, 3);
+                test.ok(response.response.outputSpeech.ssml.indexOf('break time') != -1);
+                test.end()
+            },
+            fail: function (error) {
+                test.fail()
+            }
+        });
     }
 );
 


### PR DESCRIPTION
E.g. "Tell me the latest film reviews" returns the latest 3 film reviews.
After this, it follows the same logic as headlines - the user can either say e.g. "the first one", or "more" to get the next 3 results.

If the user asks "Tell me the latest reviews", they are prompted to specify the type.

TODO in another PR - rewrite logic for reviews for a specific search term + review type (`src/intentLogic/getReview.js`)