### PR TITLE
Introduce topics

### DIFF
--- a/src/capiQueryBuilder.js
+++ b/src/capiQueryBuilder.js
@@ -1,0 +1,504 @@
+const config = require("../tmp/config.json");
+const helpers = require('./helpers');
+
+const CAPI_API_KEY = config.capi_key;
+const BASE_URL = "https://content.guardianapis.com/";
+
+exports.newsQuery = (offset, locale, topic) => {
+    const props = getQueryProperties(locale, topic);
+    if (props !== null) {
+        return BASE_URL + props.path + "?"
+            + "&api-key=" + CAPI_API_KEY
+            + "&show-fields=byline,headline"
+            + "&tags=type/article,-tone/minutebyminute"
+            + (props.toneNews ? ",tone/news" : "")
+            + (props.editorsPicks ? "&show-editors-picks=true" : getPageParams(offset))
+    } else {
+        console.log(`newsQuery: failed to find properties for ${locale} / ${topic}`);
+        return null;
+    }
+};
+
+exports.opinionQuery = (offset, locale, topic) => {
+    const getProps = () => {
+        if (topic) {
+            return getQueryProperties(locale, topic);
+        } else {
+            //Top-level comment by edition
+            return {
+                path: localeToEdition(locale) + "/commentisfree"
+            }
+        }
+    };
+
+    const props = getProps();
+    if (props !== null) {
+        return BASE_URL + props.path + "?"
+            + "&api-key=" + CAPI_API_KEY
+            + "&show-fields=byline,headline"
+            + "&tags=type/article,-tone/minutebyminute"
+            + ",tone/comment"
+            + getPageParams(offset);
+    } else {
+        console.log(`opinionQuery: failed to find properties for ${locale} / ${topic}`);
+        return null;
+    }
+};
+
+exports.reviewQuery = (offset, reviewType) => {
+    const tagType = reviewTypeToTag(reviewType);
+    if (tagType !== null) {
+        return BASE_URL + "search"
+            + "?api-key=" + CAPI_API_KEY
+            + getPageParams(offset)
+            + "&tag=tone/reviews,"+ tagType
+            + "&show-fields=standfirst,byline,headline&show-blocks=all";
+    } else {
+        console.log(`reviewQuery: invalid review_type: ${reviewType}`);
+        return null;
+    }
+};
+
+const localeToEdition = (locale) => {
+    switch (locale) {
+        case 'en-US': return 'us';
+        case 'en-GB': return 'uk';
+        case 'en-AU': return 'au';
+        default: return 'uk';
+    }
+};
+
+const reviewTypeToTag = (reviewType) => {
+    switch (reviewType) {
+        case 'film':
+        case 'films':
+            return 'film/film';
+            break;
+        case 'restaurant':
+        case 'restaurants':
+            return 'lifeandstyle/restaurants';
+            break;
+        case 'book':
+        case 'books':
+            return 'books/books';
+            break;
+        case 'music':
+            return 'music/music';
+            break;
+        default:
+            return null
+    }
+};
+
+const getQueryProperties = (locale, topic) => {
+    const edition = localeToEdition(locale);
+    const props = queryProperties(topic  ? topic : edition);
+    if (props !== null) {
+        if (props[edition]) return props[edition];
+        else return props.default;
+    } else return null;
+};
+
+const getPageParams = (offset) => {
+    return "&page-size="+ helpers.pageSize +"&page="+ ((offset / helpers.pageSize) + 1)
+};
+
+/**
+ * Get the properties object for a topic. This defines how to build the capi query.
+ * The topics here should match the set of topics defined in the Amazon Echo custom slot type 'topic'.
+ * Each properties object can contain multiple objects for different editions, but it must have a 'default'
+ * object.
+ */
+const queryProperties = (topic) => {
+    switch (topic.toLowerCase()) {
+        case "united kingdom":
+        case "uk": return {
+            default: {
+                toneNews: true,       //tags=tone/news
+                editorsPicks: true,   //show-editors-picks
+                path: "uk"
+            }
+        };
+        case "united states":
+        case "usa":
+        case "us": return {
+            default: {
+                toneNews: true,
+                editorsPicks: true,
+                path: "us"
+            }
+        };
+        case "australia":
+        case "au": return {
+            default: {
+                toneNews: true,
+                editorsPicks: true,
+                path: "au"
+            }
+        };
+        case "international": return {
+            default: {
+                toneNews: true,
+                editorsPicks: true,
+                path: "international"
+            }
+        };
+        case "world": return {
+            default: {
+                toneNews: true,
+                editorsPicks: true,
+                path: "world"
+            }
+        };
+        case "politics": return {
+            default: {
+                //UK politics
+                toneNews: true,
+                editorsPicks: true,
+                path: "politics"
+            },
+            us: {
+                toneNews: true,
+                editorsPicks: false,
+                path: "us-news/us-politics"
+            }
+        };
+        case "sport": return {
+            default: {
+                toneNews: true,
+                editorsPicks: true,
+                path: "uk/sport"
+            },
+            us: {
+                toneNews: true,
+                editorsPicks: true,
+                path: "us/sport"
+            },
+            au: {
+                toneNews: true,
+                editorsPicks: true,
+                path: "au/sport"
+            }
+        };
+        case "football":
+        case "soccer": return {
+            default: {
+                toneNews: true,
+                editorsPicks: true,
+                path: "football"
+            }
+        };
+        case "cricket": return {
+            default: {
+                toneNews: true,
+                editorsPicks: false,
+                path: "sport/cricket"
+            }
+        };
+        case "rugby":
+        case "rugby union": return {
+            default: {
+                toneNews: true,
+                editorsPicks: false,
+                path: "sport/rugby-union"
+            }
+        };
+        case "formula 1":
+        case "f1": return {
+            default: {
+                toneNews: true,
+                editorsPicks: false,
+                path: "sport/formulaone"
+            }
+        };
+        case "tennis": return {
+            default: {
+                toneNews: true,
+                editorsPicks: false,
+                path: "sport/tennis"
+            }
+        };
+        case "golf": return {
+            default: {
+                toneNews: true,
+                editorsPicks: false,
+                path: "sport/golf"
+            }
+        };
+        case "cycling": return {
+            default: {
+                toneNews: true,
+                editorsPicks: false,
+                path: "sport/cycling"
+            }
+        };
+        case "boxing": return {
+            default: {
+                toneNews: true,
+                editorsPicks: false,
+                path: "sport/boxing"
+            }
+        };
+        case "horse racing": return {
+            default: {
+                toneNews: true,
+                editorsPicks: false,
+                path: "sport/horse-racing"
+            }
+        };
+        case "rugby league": return {
+            default: {
+                toneNews: true,
+                editorsPicks: false,
+                path: "sport/rugbyleague"
+            }
+        };
+        case "film":
+        case "movies": return {
+            default: {
+                toneNews: true,
+                editorsPicks: true,
+                path: "uk/film"
+            },
+            us: {
+                toneNews: true,
+                editorsPicks: true,
+                path: "us/film"
+            },
+            au: {
+                toneNews: true,
+                editorsPicks: true,
+                path: "au/film"
+            }
+        };
+        case "tv":
+        case "radio":
+        case "tv and radio": return {
+            default: {
+                toneNews: false,
+                editorsPicks: true,
+                path: "tv-and-radio"
+            }
+        };
+        case "music": return {
+            default: {
+                toneNews: false,
+                editorsPicks: true,
+                path: "music"
+            }
+        };
+        case "games": return {
+            default: {
+                toneNews: false,
+                editorsPicks: false,
+                path: "technology/games"
+            }
+        };
+        case "books": return {
+            default: {
+                toneNews: false,
+                editorsPicks: true,
+                path: "books"
+            }
+        };
+        case "art": return {
+            default: {
+                toneNews: false,
+                editorsPicks: true,
+                path: "artanddesign"
+            }
+        };
+        case "stage": return {
+            default: {
+                toneNews: false,
+                editorsPicks: true,
+                path: "stage"
+            }
+        };
+        case "business": return {
+            default: {
+                toneNews: true,
+                editorsPicks: true,
+                path: "uk/business"
+            },
+            us: {
+                toneNews: true,
+                editorsPicks: true,
+                path: "us/business"
+            },
+            au: {
+                toneNews: true,
+                editorsPicks: true,
+                path: "au/business"
+            }
+        };
+        case "life and style":
+        case "lifestyle": return {
+            default: {
+                toneNews: false,
+                editorsPicks: true,
+                path: "uk/lifeandstyle"
+            },
+            us: {
+                toneNews: false,
+                editorsPicks: true,
+                path: "us/lifeandstyle"
+            },
+            au: {
+                toneNews: false,
+                editorsPicks: true,
+                path: "au/lifeandstyle"
+            }
+        };
+        case "food": return {
+            default: {
+                toneNews: false,
+                editorsPicks: true,
+                path: "lifeandstyle/food-and-drink"
+            }
+        };
+        case "health":
+        case "fitness":
+        case "wellbeing": return {
+            default: {
+                toneNews: false,
+                editorsPicks: true,
+                path: "lifeandstyle/health-and-wellbeing"
+            }
+        };
+        case "sex":
+        case "love": return {
+            default: {
+                toneNews: false,
+                editorsPicks: true,
+                path: "lifeandstyle/love-and-sex"
+            }
+        };
+        case "family": return {
+            default: {
+                toneNews: false,
+                editorsPicks: true,
+                path: "lifeandstyle/family"
+            }
+        };
+        case "women": return {
+            default: {
+                toneNews: false,
+                editorsPicks: true,
+                path: "lifeandstyle/women"
+            }
+        };
+        case "garden":
+        case "home": return {
+            default: {
+                toneNews: false,
+                editorsPicks: true,
+                path: "lifeandstyle/home-and-garden"
+            }
+        };
+        case "fashion": return {
+            default: {
+                toneNews: false,
+                editorsPicks: true,
+                path: "fashion"
+            }
+        };
+        case "environment": return {
+            default: {
+                toneNews: true,
+                editorsPicks: true,
+                path: "uk/environment"
+            },
+            us: {
+                toneNews: true,
+                editorsPicks: true,
+                path: "us/environment"
+            },
+            au: {
+                toneNews: true,
+                editorsPicks: true,
+                path: "au/environment"
+            }
+        };
+        case "climate change": return {
+            default: {
+                toneNews: true,
+                editorsPicks: false,
+                path: "environment/climate-change"
+            }
+        };
+        case "technology":
+        case "tech": return {
+            default: {
+                toneNews: true,
+                editorsPicks: true,
+                path: "uk/technology"
+            },
+            us: {
+                toneNews: true,
+                editorsPicks: true,
+                path: "us/technology"
+            }
+        };
+        case "travel": return {
+            default: {
+                toneNews: false,
+                editorsPicks: true,
+                path: "uk/travel"
+            },
+            us: {
+                toneNews: false,
+                editorsPicks: true,
+                path: "us/travel"
+            },
+            au: {
+                toneNews: false,
+                editorsPicks: true,
+                path: "au/travel"
+            }
+        };
+        case "culture": return {
+            default: {
+                toneNews: false,
+                editorsPicks: true,
+                path: "uk/culture"
+            },
+            us: {
+                toneNews: false,
+                editorsPicks: true,
+                path: "us/culture"
+            },
+            au: {
+                toneNews: false,
+                editorsPicks: true,
+                path: "au/culture"
+            }
+        };
+        case "science": return {
+            default: {
+                toneNews: true,
+                editorsPicks: true,
+                path: "science"
+            }
+        };
+        case "money": return {
+            default: {
+                toneNews: true,
+                editorsPicks: true,
+                path: "uk/money"
+            },
+            us: {
+                toneNews: true,
+                editorsPicks: true,
+                path: "us/money"
+            },
+            au: {
+                toneNews: true,
+                editorsPicks: true,
+                path: "au/money"
+            }
+        };
+
+        default: return null;
+    }
+};

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -2,7 +2,7 @@ const config = require("../tmp/config.json");
 const CAPI_API_KEY = config.capi_key;
 
 exports.capiQuery = function(endpoint, filter, q) {
-    var capiHost = 'http://content.guardianapis.com/';
+    var capiHost = 'https://content.guardianapis.com/';
     var key = '&api-key=' + CAPI_API_KEY;
     var query = q ? '&q=' + q : '';
     return capiHost + endpoint + '?' + filter + query + key;
@@ -44,3 +44,15 @@ exports.localizeEdition = (locale) => {
     }
 };
 
+/**
+ * Set the topic based on the lastIntent.
+ * If it's a new intent then the topic is set using only the slots.
+ * If the last intent was MoreIntent or EntityIntent then only use the attributes.
+ */
+exports.getTopic = (attributes, slots) => {
+    switch (attributes.lastIntent) {
+        case "MoreIntent":
+        case "EntityIntent": return attributes.topic ? attributes.topic : null;
+        default: return (slots.topic && slots.topic.value) ? slots.topic.value : null;
+    }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -35,14 +35,17 @@ var handlers = {
     },
 
     'GetIntroNewsIntent': function() {
+        this.event.session.attributes.lastIntent = 'GetIntroNewsIntent';
         this.emit(':ask', speech.news.explainer + randomMsg(speech.core.questions), speech.news.reprompt)
     },
 
     'GetIntroReviewsIntent': function() {
+        this.event.session.attributes.lastIntent = 'GetIntroReviewsIntent';
         this.emit(':ask', speech.reviews.explainer + randomMsg(speech.core.questions), speech.reviews.reprompt)
     },
 
     'GetIntroSportIntent': function() {
+        this.event.session.attributes.lastIntent = 'GetIntroSportIntent';
         this.emit(':ask', speech.sport.explainer + randomMsg(speech.core.questions), speech.sport.reprompt)
     },
 
@@ -51,19 +54,68 @@ var handlers = {
     'ReadContentAtPositionIntent': readContentAtPosition,
 
     'MoreIntent': function() {
-        // repeat last intent action with increased offSet
-        this.emit(this.event.session.attributes.lastIntent, false);
+        const lastIntent = this.event.session.attributes.lastIntent;
+        switch (lastIntent) {
+            case 'GetHeadlinesIntent':
+            case 'GetLatestReviewsIntent':
+            case 'GetOpinionIntent':
+                // repeat last intent action with increased offSet
+                this.event.session.attributes.lastIntent = 'MoreIntent';
+                this.emit(lastIntent);
+                break;
+
+            default:
+                this.emit(':ask', speech.help.reprompt)
+        }
     },
     'GetOpinionIntent': getOpinion,
 
     'GetLatestReviewsIntent': getLatestReviews,
 
-    //The user has specified a review_type. The reviews intents will prompt for one if missing.
-    'ReviewTypeIntent': function() {
+    /**
+     * This may be a topic or a review_type. 
+     * This is because there is some cross-over between the two, so we need a single handler.
+     * We let the appropriate intent handler decide if the entity is valid.
+     * Note - we also use the name 'entity' in the attributes. This is because the user may not
+     * yet have told us which intent they want, but we need to store the value now.
+     */
+    'EntityIntent': function() {
+        const attributes = this.event.session.attributes;
         const slots = this.event.request.intent.slots;
-        if (slots.review_type && slots.review_type.value) {
-            this.event.session.attributes.reviewType = slots.review_type.value;
-            this.emit(this.event.session.attributes.lastIntent)
+        const getEntity = () => {
+            if (slots.topic && slots.topic.value) return slots.topic.value;
+            if (slots.review_type && slots.review_type.value) return slots.review_type.value;
+            return null;
+        };
+
+        const entity = getEntity();
+
+        if (entity !== null) {
+            if (entity.toLowerCase() === "sport" && attributes.lastIntent === "Launch") {
+                //Special case - show the sports intro if the skill has just been launched
+                this.emit('GetIntroSportIntent')
+            } else {
+                switch (attributes.lastIntent) {
+                    case 'GetLatestReviewsIntent':
+                    case 'GetIntroReviewsIntent' :
+                        attributes.lastIntent = "EntityIntent";
+                        attributes.reviewType = entity;
+                        this.emit('GetLatestReviewsIntent');
+                        break;
+                    case 'GetIntroNewsIntent':
+                        attributes.lastIntent = "EntityIntent";
+                        attributes.topic = entity;
+                        this.emit('GetHeadlinesIntent');
+                        break;
+                    default:
+                        // No last intent or unexpected last intent
+                        this.emit(':ask', speech.help.reprompt)
+                }
+            }
+        } else {
+            //This should never happen
+            console.log(`Missing entity for EntityIntent: ${this.event.request}`);
+            this.emit(':ask', speech.help.reprompt)
         }
     },
 

--- a/src/intentLogic/getHeadlines.js
+++ b/src/intentLogic/getHeadlines.js
@@ -1,78 +1,85 @@
 const get = require('simple-get-promise').get;
 const asJson = require('simple-get-promise').asJson;
 
-const helpers = require('../helpers');
 const speech = require('../speech').speech;
 const sound = require('../speech').sound;
 const randomMsg = require('../helpers').randomMessage;
-const getSectionPath = require('../helpers').getSectionPath;
 const getMoreOffset = require('../helpers').getMoreOffset;
-const localizeEdition = require('../helpers').localizeEdition;
+const getTopic = require('../helpers').getTopic;
 
-module.exports = function (isNewIntentFlag) {
-    // An intent is a new intent unless this is explicitly set to `false`; `undefined` defaults to `true`.
-    const isNewIntent = isNewIntentFlag !== false;
+const capiQueryBuilder = require('../capiQueryBuilder');
+
+module.exports = function () {
 
     const attributes = this.event.session.attributes;
     const slots = this.event.request.intent.slots;
 
-    attributes.lastIntent = 'GetHeadlinesIntent';
-    if (isNewIntent) attributes.sectionType = slots.section_type ? slots.section_type.value : null;
+    const isNewIntent = attributes.lastIntent !== "MoreIntent";
+
+    attributes.topic = getTopic(attributes, slots);
 
     attributes.moreOffset = getMoreOffset(isNewIntent, attributes.moreOffset);
+    attributes.lastIntent = 'GetHeadlinesIntent';
 
-    get(buildCapiQuery(attributes.sectionType, this.event.request.locale))
-        .then(asJson)
-        .then((json) => {
-            if (json.response.editorsPicks && json.response.editorsPicks.length >= attributes.moreOffset) {
-                updatePositionalContent(json); // side effects, yay!
-                this.emit(':ask', generateHeadlinesSpeech(json));
-            } else {
-                this.emit(':ask', speech.headlines.notfound);
-            }
-        })
-        .catch(function (error) {
-            this.emit(':tell', speech.headlines.notfound);
-        });
+    const capiQuery = capiQueryBuilder.newsQuery(attributes.moreOffset, this.event.request.locale, attributes.topic);
+    if (capiQuery !== null) {
 
-    var generateHeadlinesSpeech = (json) => {
-    const preamble = generatePreamble(isNewIntent, attributes.sectionType, json.response.editorsPicks.length);
-    const conclusion = sound.strongBreak + followupQuestion(json.response.editorsPicks.length);
-
-        var getHeadlines = () => {
-            return json.response.editorsPicks.slice(attributes.moreOffset, attributes.moreOffset+3).map(editorsPick =>
-                editorsPick.fields.headline + sound.transition
-            );
-        };
-
-    return preamble + getHeadlines() + conclusion;
-  };
-
-  var updatePositionalContent = (json) => {
-    attributes.positionalContent = json.response.editorsPicks.slice(attributes.moreOffset, attributes.moreOffset+3).map(editorsPick =>
-      editorsPick.id );
-  };
+        get(capiQuery)
+            .then(asJson)
+            .then((json) => {
+                const results = getResults(json, attributes.moreOffset);
+                if (results !== null) {
+                    attributes.positionalContent = results.map(result => result.id);
+                    this.emit(':ask', generateHeadlinesSpeech(results, isNewIntent, attributes.topic));
+                } else {
+                    this.emit(':ask', speech.headlines.notfound);
+                }
+            })
+            .catch(function (error) {
+                this.emit(':tell', speech.headlines.notfound);
+            });
+    } else {
+        this.emit(':tell', speech.headlines.notfound);
+    }
 };
 
-var buildCapiQuery = (sectionType, locale) => {
-
-    const path = getSectionPath(sectionType, localizeEdition(locale));
-    const showEditorsPicks = 'show-editors-picks=true';
-    const showFields = '&show-fields=byline,headline&tag=type/article,tone/news,-tone/minutebyminute';
-    const filters = showEditorsPicks + showFields;
-
-    return helpers.capiQuery(path, filters);
-
+/**
+ * Return the array of results, or null if none found.
+ * If the editors-picks field is present, use that, otherwise use the main results.
+ */
+const getResults = (json, moreOffset) => {
+    if (json.response.editorsPicks) {
+        if (json.response.editorsPicks.length >= moreOffset) {
+            return json.response.editorsPicks.slice(moreOffset, moreOffset+3);
+        } else {
+            return null;
+        }
+    } else {
+        if (json.response.results && json.response.results.length > 0) {
+            return json.response.results;
+        } else {
+            return null;
+        }
+    }
 };
 
-var generatePreamble = (isNewIntent, sectionType, howManyStories) => {
+const generateHeadlinesSpeech = (results, isNewIntent, topic) => {
+    const preamble = generatePreamble(isNewIntent, topic, results.length);
+    const conclusion = sound.strongBreak + followupQuestion(results.length);
+    const headlines = results.map(result => result.fields.headline + sound.transition);
+
+    return preamble + headlines + conclusion;
+};
+
+const generatePreamble = (isNewIntent, topic, howManyStories) => {
     const ack = randomMsg(speech.acknowledgement);
     const numberOfStoriesReturned = howManyStories >= 3 ? 3 : howManyStories;
 
     const buildStories = () => {
-        if (sectionType) {
+        if (topic) {
+            if (isNewIntent) return `the top ${numberOfStoriesReturned} ${topic} stories are: `;
             if (numberOfStoriesReturned == 1) return `the next story is: `;
-            else return `the next ${numberOfStoriesReturned} ${sectionType} stories are; `
+            return `the next ${numberOfStoriesReturned} ${topic} stories are; `
         }
         if (isNewIntent) return `the top ${numberOfStoriesReturned} stories are: `;
         return speech.headlines.more;
@@ -81,9 +88,8 @@ var generatePreamble = (isNewIntent, sectionType, howManyStories) => {
     return ack + buildStories();
 };
 
-var followupQuestion = (howManyStories) => {
+const followupQuestion = (howManyStories) => {
     if (howManyStories == 1) return speech.headlines.followup1;
     if (howManyStories == 2) return speech.headlines.followup2;
     return speech.headlines.followup3
 };
-

--- a/src/speech.js
+++ b/src/speech.js
@@ -6,7 +6,7 @@ const speech = {
     news: {
         explainer: `'OK great. I can give you more than just the headlines. For example, ask: give me the sport headlines.
         If you want me to read you stories on a topic. Ask: give me the latest on Brexit.
-        And finally, if you want me to hear the latest opinions on a topic. Say: give me the latest opinions on Brexit.'`,
+        And finally, if you want me to hear the latest opinions on a topic. Say: give me the latest opinions on Brexit. '`,
         reprompt: 'Sorry, what headlines would you like to hear?'
     },
     sport: {
@@ -16,7 +16,7 @@ const speech = {
     headlines: {
         top: 'the top three stories are: ',
         more: 'the next three stories are: ',
-        notfound: 'Sorry, I could not find you any headlines.',
+        notfound: 'Sorry, I could not find you any headlines. ',
         followup1: 'Would you like me to read the first story?',
         followup2: 'Would you like me to read the first or second story?',
         followup3: 'Would you like me to read the first, second or third story or would you like more headlines?',
@@ -54,7 +54,7 @@ const speech = {
         clarifyType: 'Is it a restaurant, book, film, or music review you\'re after?',
         clarifySearch: 'What would you like a {0} review for?',
         reprompt: 'Would you like to hear another review?',
-        explainer: 'I have reviews for films, books, music and restaurants. Just say: give me the latest restaurant reviews.',
+        explainer: 'I have reviews for films, books, music and restaurants. Just say: give me the latest restaurant reviews. ',
         followup1: 'Would you like me to read this review?',
         followup2: 'Would you like me to read the first review or the second review?',
         followup3: 'Would you like me to read the first, second or third review or would you like more reviews?'
@@ -64,8 +64,8 @@ const speech = {
         reprompt: 'Sorry, what would you like to do?'
     },
     core: {
-        stop: 'Speak to you again soon.',
-        cancel: 'Speak to you again soon.',
+        stop: 'Speak to you again soon. ',
+        cancel: 'Speak to you again soon. ',
         didNotUnderstand: 'Sorry, I didn\'t catch that',
         questions: [
             'What would you like to hear?',
@@ -78,7 +78,7 @@ const speech = {
         followup: 'Would you like to hear the headlines again, or more headlines?',
         articleBy: 'This article is written by ',
         timeToReadPref: ' and it will take roughly ',
-        timeToReadSuff: ' minutes to read.'
+        timeToReadSuff: ' minutes to read. '
     },
     acknowledgement: [
         'Sure, ',

--- a/test/fixtures/getHeadlinesForTopic.json
+++ b/test/fixtures/getHeadlinesForTopic.json
@@ -23,8 +23,8 @@
         "intent": {
             "name": "GetHeadlinesIntent",
             "slots": {
-                "section_type": {
-                    "name": "section_type",
+                "topic": {
+                    "name": "topic",
                     "value": "politics"
                 }
             }

--- a/test/fixtures/getInexistentOpinion.json
+++ b/test/fixtures/getInexistentOpinion.json
@@ -19,8 +19,8 @@
         "intent": {
             "name": "GetOpinionIntent",
             "slots": {
-                "search_term": {
-                    "name": "search_term",
+                "topic": {
+                    "name": "topic",
                     "value": "lskdfjslkfjasldkfjlaksdjflsjdflaskjdflsakdfjlsa"
                 }
             }

--- a/test/fixtures/getLocalizedOpinion.json
+++ b/test/fixtures/getLocalizedOpinion.json
@@ -5,7 +5,6 @@
       "applicationId": ""
     },
     "attributes": {
-        "lastIntent": "GetLatestReviewsIntent"
     },
     "user": {
       "userId": ""
@@ -15,17 +14,13 @@
   "request": {
     "type": "IntentRequest",
     "requestId": "",
-    "locale": "en-GB",
-    "timestamp": "2016-08-31T09:44:11Z",
+    "locale": "en-US",
+    "timestamp": "2016-08-08T14:18:45Z",
     "intent": {
-      "name": "EntityIntent",
+      "name": "GetOpinionIntent",
       "slots": {
-        "review_type": {
-          "name": "review_type",
-          "value": "film"
-        }
       }
-    }
-  },
-  "version": "1.0"
+    },
+    "version": "1.0"
+  }
 }

--- a/test/fixtures/getOpinionOn.json
+++ b/test/fixtures/getOpinionOn.json
@@ -19,9 +19,9 @@
         "intent": {
             "name": "GetOpinionIntent",
             "slots": {
-                "search_term": {
-                    "name": "search_term",
-                    "value": "Brexit"
+                "topic": {
+                    "name": "topic",
+                    "value": "sport"
                 }
             }
         },

--- a/test/fixtures/moreAfterSportOpinions.json
+++ b/test/fixtures/moreAfterSportOpinions.json
@@ -6,7 +6,7 @@
         },
         "attributes": {
             "moreOffset": 0,
-            "searchTerm": "brexit",
+            "topic": "sport",
             "lastIntent": "GetOpinionIntent",
             "positionalContent": [
                 "commentisfree/2016/jul/07/stories-buried-brexit-child-poverty-un-austerity",

--- a/test/fixtures/moreAfterTechHeadlines.json
+++ b/test/fixtures/moreAfterTechHeadlines.json
@@ -8,7 +8,7 @@
             "moreOffset": 0,
             "lastIntent": "GetHeadlinesIntent",
             "positionalContent": [],
-            "sectionType": "technology"
+            "topic": "technology"
         },
         "user": {
             "userId": ""

--- a/test/fixtures/topicAfterNewsIntro.json
+++ b/test/fixtures/topicAfterNewsIntro.json
@@ -5,24 +5,27 @@
       "applicationId": ""
     },
     "attributes": {
-        "lastIntent": "GetLatestReviewsIntent"
+      "moreOffset": 0,
+      "lastIntent": "GetIntroNewsIntent",
+      "positionalContent": [
+      ]
     },
     "user": {
       "userId": ""
     },
-    "new": true
+    "new": false
   },
   "request": {
     "type": "IntentRequest",
     "requestId": "",
-    "locale": "en-GB",
-    "timestamp": "2016-08-31T09:44:11Z",
+    "locale": "en-US",
+    "timestamp": "2016-08-23T15:25:17Z",
     "intent": {
       "name": "EntityIntent",
       "slots": {
-        "review_type": {
-          "name": "review_type",
-          "value": "film"
+        "topic": {
+          "name": "topic",
+          "value": "politics"
         }
       }
     }

--- a/test/index.js
+++ b/test/index.js
@@ -1,14 +1,16 @@
 const tap = require('tap');
 
 const headLinesJson = require('./fixtures/getHeadlines.json');
-const headLineSectionJson = require('./fixtures/getHeadlinesForSection.json');
+const headLineTopicJson = require('./fixtures/getHeadlinesForTopic.json');
+const topicAfterNewsIntro = require('./fixtures/topicAfterNewsIntro.json');
 const opinionJson = require('./fixtures/getOpinionOn.json');
+const localizedOpinion = require('./fixtures/getLocalizedOpinion.json');
 const inexistentOpinionJson = require('./fixtures/getInexistentOpinion.json');
 const latestReviewsJson = require('./fixtures/getLatestReviews.json');
 const posAfterHeadJson = require('./fixtures/positionalContentAfterHeadlines.json');
 const moreAfterHeadlines = require('./fixtures/moreAfterHeadlines.json');
 const moreAfterTechHeadlines = require('./fixtures/moreAfterTechHeadlines.json');
-const moreAfterBrexitOpinion = require('./fixtures/moreAfterBrexitOpinions.json');
+const moreAfterSportOpinion = require('./fixtures/moreAfterSportOpinions.json');
 const localizedHeadlines = require('./fixtures/getLocalizedHeadlines.json');
 const moreAfterLatestReviews = require('./fixtures/moreAfterLatestReviews.json');
 const reviewTypeAfterLatestReviews = require('./fixtures/reviewTypeAfterLatestReviews.json');
@@ -39,7 +41,6 @@ tap.test('Test localized headlines intent', test => {
         lambda(
             localizedHeadlines, {
                 succeed: function (response) {
-                    console.log(response);
                     test.equal(response.sessionAttributes.lastIntent, "GetHeadlinesIntent");
                     test.equal(response.sessionAttributes.positionalContent.length, 3);
                     test.ok(response.response.outputSpeech.ssml.indexOf('break time') != -1);
@@ -52,15 +53,33 @@ tap.test('Test localized headlines intent', test => {
     }
 );
 
-tap.test('Test get headlines intent with a specific section', test => {
+tap.test('Test topic after news intro', test => {
+        test.plan(4);
+        lambda(
+            topicAfterNewsIntro, {
+                succeed: function (response) {
+                    test.equal(response.sessionAttributes.lastIntent, "GetHeadlinesIntent");
+                    test.equal(response.sessionAttributes.positionalContent.length, 3);
+                    test.ok(response.response.outputSpeech.ssml.indexOf('break time') != -1);
+                    test.equal(response.sessionAttributes.topic, 'politics');
+                    test.end()
+                },
+                fail: function (error) {
+                    test.fail()
+                }
+            });
+    }
+);
+
+tap.test('Test get headlines intent with a specific topic', test => {
     test.plan(4);
     lambda(
-        headLineSectionJson, {
+        headLineTopicJson, {
             succeed: function (response) {
                 test.equal(response.sessionAttributes.lastIntent, "GetHeadlinesIntent");
                 test.equal(response.sessionAttributes.positionalContent.length, 3);
                 test.ok(response.response.outputSpeech.ssml.indexOf('break time') != -1);
-                test.equal(response.sessionAttributes.sectionType, 'politics');
+                test.equal(response.sessionAttributes.topic, 'politics');
                 test.end()
             },
             fail: function (error) {
@@ -70,15 +89,32 @@ tap.test('Test get headlines intent with a specific section', test => {
     }
 );
 
-tap.test('Test the get opinion on Brexit intent', test => {
+tap.test('Test the get opinion on sport intent', test => {
+        test.plan(3);
+        lambda(
+            localizedOpinion, {
+                succeed: function (response) {
+                    test.equal(response.sessionAttributes.lastIntent, "GetOpinionIntent");
+                    test.ok(response.response.outputSpeech.ssml.indexOf('break time') != -1);
+                    test.equal(response.sessionAttributes.positionalContent.length, 3);
+                    test.end()
+                },
+                fail: function (error) {
+                    test.fail()
+                }
+            });
+    }
+);
+
+tap.test('Test the get opinion on sport intent', test => {
     test.plan(5);
     lambda(
         opinionJson, {
             succeed: function (response) {
                 test.equal(response.sessionAttributes.lastIntent, "GetOpinionIntent");
-                test.ok(response.response.outputSpeech.ssml.indexOf('Brexit') != -1);
+                test.ok(response.response.outputSpeech.ssml.indexOf('sport') != -1);
                 test.ok(response.response.outputSpeech.ssml.indexOf('break time') != -1);
-                test.equal(response.sessionAttributes.searchTerm, 'Brexit');
+                test.equal(response.sessionAttributes.topic, 'sport');
                 test.equal(response.sessionAttributes.positionalContent.length, 3);
                 test.end()
             },
@@ -89,14 +125,14 @@ tap.test('Test the get opinion on Brexit intent', test => {
     }
 );
 
-tap.test('Test more intent after Brexit opinion', test => {
+tap.test('Test more intent after sport opinion', test => {
         test.plan(4);
         lambda(
-            moreAfterBrexitOpinion, {
+            moreAfterSportOpinion, {
                 succeed: function (response) {
-                    test.ok(response.response.outputSpeech.ssml.indexOf("the next 3 brexit stories are") != -1);
+                    test.ok(response.response.outputSpeech.ssml.indexOf("the next 3 sport stories are") != -1);
                     test.equal(response.sessionAttributes.moreOffset, 3);
-                    test.equal(response.sessionAttributes.searchTerm, 'brexit');
+                    test.equal(response.sessionAttributes.topic, 'sport');
                     test.equal(response.sessionAttributes.lastIntent, "GetOpinionIntent");
                     test.end();
                 },
@@ -107,7 +143,7 @@ tap.test('Test more intent after Brexit opinion', test => {
     }
 );
 
-tap.test('Test opinion intent with a search item that does not return any result', test => {
+tap.test('Test opinion intent with a topic that does not return any result', test => {
         test.plan(2);
         lambda(
             inexistentOpinionJson, {
@@ -157,12 +193,13 @@ tap.test('Test get more reviews after latest reviews intent', test => {
     }
 );
 
-tap.test('Test review_type after get latest reviews intent', test => {
-    test.plan(3);
+tap.test('Test entity after get latest reviews intent', test => {
+    test.plan(4);
     lambda(
         reviewTypeAfterLatestReviews, {
             succeed: function (response) {
                 test.equal(response.sessionAttributes.lastIntent, "GetLatestReviewsIntent");
+                test.equal(response.sessionAttributes.reviewType, "film");
                 test.equal(response.sessionAttributes.positionalContent.length, 3);
                 test.ok(response.response.outputSpeech.ssml.indexOf('break time') != -1);
                 test.end()


### PR DESCRIPTION
### Background
Amazon are removing support for the LITERAL slot type, which allowed the user to specify arbitrary search terms. This means we have to use the custom slot types, which require us to define a set of valid values (though apparently it's not quite like an enum...)

### Topics
So this change introduces the `topic` slot type. This is the set of all things that a user can ask for when getting headlines or opinions. Our app then has to map each topic to a CAPI query. Many topics may map to the same query (e.g. "technology", "tech"). The locale of the user may affect the form of the query (e.g. `politics` + `en_UK`=> `/politics`, but `politics` + `en_US` => `/us-news/us-politics`).

For headlines, the following vary depending on the topic + locale:
- the use of editors-picks vs main results
- the use of the tone/news tag

### EntityIntent
This is a bit clunky, but we need an intent that can handle both `topic` and `review_type`. This is because e.g. `film` may be classified as either by alexa. This intent gets the value (the 'entity'), sets the `entity` attribute in the context, and triggers the relevant intent (`GetHeadlinesIntent` or `GetLatestReviewsIntent`), or asks the user to specify the intent. We use the `entity` attribute field here because we may not yet know the intent.