### PR TITLE
Hit Ophan endpoint for analytics

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,11 +1,30 @@
 const config = require("../tmp/config.json");
 const CAPI_API_KEY = config.capi_key;
+const get = require('simple-get-promise').get;
 
 exports.capiQuery = function(endpoint, filter, q) {
     var capiHost = 'https://content.guardianapis.com/';
     var key = '&api-key=' + CAPI_API_KEY;
     var query = q ? '&q=' + q : '';
     return capiHost + endpoint + '?' + filter + query + key;
+};
+
+exports.hitOphanEndpoint = function(url, userId, addUrl) {
+    addUrl = addUrl || false;
+    var viewId = new Date().getTime().toString(36) + 'xxxxxxxxxxxx'.replace(/x/g, function () {
+        return Math.floor(Math.random() * 36).toString(36);
+    });
+
+    const ophanUrl = 'https://ophan.theguardian.com/i.gif';
+    const platform = "amazon-echo";
+    const baseUrl = encodeURIComponent('https://www.theguardian.com/');
+
+    if (addUrl) url = baseUrl + url;
+    url = encodeURIComponent(url);
+    const query = `${ophanUrl}?platform=${platform}&url=${url}&viewId=${viewId}&bwid=${userId}`;
+
+    if (userId !== 'test')
+        get(query); // Ophan doesn't have callbacks or anything so that's it.
 };
 
 exports.randomMessage = function(messages) {

--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,7 @@ var handlers = {
     'GetPodcastIntent': getPodcast,
 
     'PlayPodcastIntent': function(jsonObj) {
+
         this.context.succeed(jsonObj);
     },
 

--- a/src/intentLogic/getHeadlines.js
+++ b/src/intentLogic/getHeadlines.js
@@ -8,8 +8,9 @@ const sound = require('../speech').sound;
 const randomMsg = require('../helpers').randomMessage;
 const getMoreOffset = require('../helpers').getMoreOffset;
 const getTopic = require('../helpers').getTopic;
-
 const capiQueryBuilder = require('../capiQueryBuilder');
+const hitOphan = require('../helpers').hitOphanEndpoint;
+const localizeEdition = require('../helpers').localizeEdition;
 
 module.exports = function () {
 
@@ -29,6 +30,14 @@ module.exports = function () {
         get(capiQuery)
             .then(asJson)
             .then((json) => {
+                if (json.response.tag !== undefined)
+                    hitOphan(json.response.tag.webUrl, this.event.session.user.userId);
+                else if (json.response.section !== undefined)
+                    hitOphan(json.response.section.webUrl, this.event.session.user.userId);
+                else {
+                    hitOphan('https://www.theguardian.com/' + capiQuery.split('?')[0].split('/').reverse()[0], this.event.session.user.userId); // front view (uk, us, au, international)
+                }
+
                 const results = getResults(json, attributes.moreOffset);
                 if (results !== null) {
                     attributes.positionalContent = results.map(result => result.id);

--- a/src/intentLogic/getLatestReviews.js
+++ b/src/intentLogic/getLatestReviews.js
@@ -7,6 +7,7 @@ const sound = require('../speech').sound;
 const randomMsg = require('../helpers').randomMessage;
 const getMoreOffset = require('../helpers').getMoreOffset;
 const helpers = require('../helpers');
+const hitOphan = require('../helpers').hitOphanEndpoint;
 
 const capiQueryBuilder = require('../capiQueryBuilder');
 
@@ -38,6 +39,8 @@ module.exports = function() {
                 .then(asJson)
                 .then(json => {
                     if (json.response.results && json.response.results.length > 1) {
+                        hitOphan(getReviewPath(attributes.reviewType), this.event.session.user.userId, true); // review fronts
+
                         attributes.positionalContent = json.response.results.map(review => review.id);
                         const preamble = getPreamble(isNewIntent, json.response.results.length, attributes.reviewType);
                         const reviews = json.response.results.map(review => {
@@ -84,7 +87,7 @@ const getHeadline = (review) => {
         if (review.fields.starRating == 1) return `${titleWithoutReview}. 1 star. `
         else return `${titleWithoutReview}. ${review.fields.starRating} stars. `
     } else return titleWithoutReview
-}
+};
 
 const getConclusion = (reviewCount) => {
     if (reviewCount == 1) return speech.reviews.followup1;
@@ -93,3 +96,12 @@ const getConclusion = (reviewCount) => {
 };
 
 const removeReviewFromTitle = (title) => title.replace(/(-|–)?\s?(book|restaurant|film|movie)? review$/, "");
+
+const getReviewPath = (reviewType) => {
+    switch (reviewType) {
+        case "film": return "film+tone/reviews";
+        case "restaurant": return "lifeandstyle/restaurants+tone/reviews";
+        case "music": return "music/music+tone/reviews";
+        case "book": return "books/books+tone/reviews";
+    }
+};

--- a/src/intentLogic/getOpinion.js
+++ b/src/intentLogic/getOpinion.js
@@ -8,7 +8,7 @@ const sound = require('../speech').sound;
 const randomMsg = require('../helpers').randomMessage;
 const getMoreOffset = require('../helpers').getMoreOffset;
 const getTopic = require('../helpers').getTopic;
-
+const hitOphan = require('../helpers').hitOphanEndpoint;
 const capiQueryBuilder = require('../capiQueryBuilder');
 
 module.exports = function () {
@@ -28,6 +28,10 @@ module.exports = function () {
         get(capiQuery)
             .then(asJson)
             .then((json) => {
+                if (json.response.tag !== undefined)
+                    hitOphan(json.response.tag.webUrl, this.event.session.user.userId);
+                else if (json.response.section !== undefined)
+                    hitOphan(json.response.section.webUrl, this.event.session.user.userId);
                 if (json.response.results && json.response.results.length > 0 && json.response.results.length > 0) {
                     attributes.positionalContent = json.response.results.map(result => result.id);
                     const opinionSpeech = generateOpinionSpeech(json.response.results, isNewIntent, attributes.topic);

--- a/src/intentLogic/readContentAtPosition.js
+++ b/src/intentLogic/readContentAtPosition.js
@@ -7,9 +7,9 @@ const helpers = require('../helpers');
 const speech = require('../speech').speech;
 const sound = require('../speech').sound;
 const randomMsg = require('../helpers').randomMessage;
-
 const config = require("../../tmp/config.json");
 const CAPI_API_KEY = config.capi_key;
+const hitOphan = require('../helpers').hitOphanEndpoint;
 
 module.exports = function () {
 
@@ -36,6 +36,7 @@ module.exports = function () {
         get(capiQuery)
             .then(asJson)
             .then((json) => {
+                hitOphan(json.response.content.webUrl, this.event.session.user.userId); // single page view
                 this.emit(':ask', getArticle(json), speech.help.reprompt);
             })
             .catch(function (error) {

--- a/src/intentLogic/yes.js
+++ b/src/intentLogic/yes.js
@@ -11,6 +11,7 @@ module.exports = function () {
     switch (attributes.lastIntent) {
         case 'GetPodcastIntent':
             const podcastDirective = helpers.getPodcastDirective(attributes.podcastUrl, attributes.podcastTitle);
+            console.log("Playing podcast " + attributes.podcastUrl);
             this.emit('PlayPodcastIntent', podcastDirective);
             break;
         case 'GetHeadlinesIntent':

--- a/test/fixtures/getFootballWeeklyPodcast.json
+++ b/test/fixtures/getFootballWeeklyPodcast.json
@@ -6,7 +6,7 @@
     },
     "attributes": {},
     "user": {
-      "userId": ""
+      "userId": "test"
     },
     "new": true
   },

--- a/test/fixtures/getHeadlines.json
+++ b/test/fixtures/getHeadlines.json
@@ -7,7 +7,7 @@
 		"attributes": {
 		},
 		"user": {
-			"userId": ""
+			"userId": "test"
 		},
 		"new": true
 	},

--- a/test/fixtures/getHeadlinesForTopic.json
+++ b/test/fixtures/getHeadlinesForTopic.json
@@ -11,7 +11,7 @@
             ]
         },
         "user": {
-            "userId": ""
+            "userId": "test"
         },
         "new": false
     },

--- a/test/fixtures/getInexistentOpinion.json
+++ b/test/fixtures/getInexistentOpinion.json
@@ -7,7 +7,7 @@
         "attributes": {
         },
         "user": {
-            "userId": ""
+            "userId": "test"
         },
         "new": true
     },

--- a/test/fixtures/getLatestReviews.json
+++ b/test/fixtures/getLatestReviews.json
@@ -6,7 +6,7 @@
     },
     "attributes": {},
     "user": {
-      "userId": ""
+      "userId": "test"
     },
     "new": true
   },

--- a/test/fixtures/getLocalizedHeadlines.json
+++ b/test/fixtures/getLocalizedHeadlines.json
@@ -7,7 +7,7 @@
         "attributes": {
         },
         "user": {
-            "userId": ""
+            "userId": "test"
         },
         "new": true
     },

--- a/test/fixtures/getLocalizedOpinion.json
+++ b/test/fixtures/getLocalizedOpinion.json
@@ -7,7 +7,7 @@
     "attributes": {
     },
     "user": {
-      "userId": ""
+      "userId": "test"
     },
     "new": true
   },

--- a/test/fixtures/getOpinionOn.json
+++ b/test/fixtures/getOpinionOn.json
@@ -7,7 +7,7 @@
         "attributes": {
         },
         "user": {
-            "userId": ""
+            "userId": "test"
         },
         "new": true
     },

--- a/test/fixtures/latestPodcast.json
+++ b/test/fixtures/latestPodcast.json
@@ -6,7 +6,7 @@
     },
     "attributes": {},
     "user": {
-      "userId": ""
+      "userId": "test"
     },
     "new": true
   },

--- a/test/fixtures/moreAfterHeadlines.json
+++ b/test/fixtures/moreAfterHeadlines.json
@@ -10,7 +10,7 @@
 			"moreOffset": 3
 		},
 		"user": {
-			"userId": ""
+			"userId": "test"
 		},
 		"new": false
 	},

--- a/test/fixtures/moreAfterLatestPodcast.json
+++ b/test/fixtures/moreAfterLatestPodcast.json
@@ -14,7 +14,7 @@
       ]
     },
     "user": {
-      "userId": ""
+      "userId": "test"
     },
     "new": false
   },

--- a/test/fixtures/moreAfterLatestReviews.json
+++ b/test/fixtures/moreAfterLatestReviews.json
@@ -10,7 +10,7 @@
         "reviewType": "film"
     },
     "user": {
-      "userId": ""
+      "userId": "test"
     },
     "new": true
   },

--- a/test/fixtures/moreAfterSportOpinions.json
+++ b/test/fixtures/moreAfterSportOpinions.json
@@ -15,7 +15,7 @@
             ]
         },
         "user": {
-            "userId": ""
+            "userId": "test"
         },
         "new": false
     },

--- a/test/fixtures/moreAfterTechHeadlines.json
+++ b/test/fixtures/moreAfterTechHeadlines.json
@@ -11,7 +11,7 @@
             "topic": "technology"
         },
         "user": {
-            "userId": ""
+            "userId": "test"
         },
         "new": false
     },

--- a/test/fixtures/posAfterLatestPodcast.json
+++ b/test/fixtures/posAfterLatestPodcast.json
@@ -14,7 +14,7 @@
       "moreOffset": 0
     },
     "user": {
-      "userId": ""
+      "userId": "test"
     },
     "new": false
   },

--- a/test/fixtures/positionalContentAfterHeadlines.json
+++ b/test/fixtures/positionalContentAfterHeadlines.json
@@ -14,7 +14,7 @@
 			"moreOffset": 0
 		},
 		"user": {
-			"userId": ""
+			"userId": "test"
 		},
 		"new": false
 	},

--- a/test/fixtures/positionalContentAfterSportOpinion.json
+++ b/test/fixtures/positionalContentAfterSportOpinion.json
@@ -1,0 +1,38 @@
+{
+  "session": {
+    "sessionId": "",
+    "application": {
+      "applicationId": ""
+    },
+    "attributes": {
+      "moreOffset": 0,
+      "topic": "sport",
+      "lastIntent": "GetOpinionIntent",
+      "positionalContent": [
+        "sport/blog/2016/oct/02/robert-young-marathon-sponsor-stands-tall",
+        "sport/2016/oct/03/cronullas-nrl-premiership-pays-back-the-loyal-fans-of-the-shire",
+        "sport/blog/2016/oct/01/ryder-cup-empty-heads-lager-atmosphere-fans-behaviour"
+      ]
+    },
+    "user": {
+      "userId": "test"
+    },
+    "new": false
+  },
+  "request": {
+    "type": "IntentRequest",
+    "requestId": "",
+    "locale": "en-GB",
+    "timestamp": "2016-10-03T14:36:11Z",
+    "intent": {
+      "name": "ReadContentAtPositionIntent",
+      "slots": {
+        "position": {
+          "name": "position",
+          "value": "1st"
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/test/fixtures/repeat.json
+++ b/test/fixtures/repeat.json
@@ -13,7 +13,7 @@
       ]
     },
     "user": {
-      "userId": ""
+      "userId": "test"
     },
     "new": false
   },

--- a/test/fixtures/reviewTypeAfterLatestReviews.json
+++ b/test/fixtures/reviewTypeAfterLatestReviews.json
@@ -8,7 +8,7 @@
         "lastIntent": "GetLatestReviewsIntent"
     },
     "user": {
-      "userId": ""
+      "userId": "test"
     },
     "new": true
   },

--- a/test/fixtures/topicAfterLaunch.json
+++ b/test/fixtures/topicAfterLaunch.json
@@ -8,7 +8,7 @@
         "lastIntent": "Launch"
     },
     "user": {
-      "userId": ""
+      "userId": "test"
     },
     "new": true
   },

--- a/test/fixtures/topicAfterNewsIntro.json
+++ b/test/fixtures/topicAfterNewsIntro.json
@@ -11,7 +11,7 @@
       ]
     },
     "user": {
-      "userId": ""
+      "userId": "test"
     },
     "new": false
   },

--- a/test/fixtures/yes.json
+++ b/test/fixtures/yes.json
@@ -7,7 +7,7 @@
 		"attributes": {
 		},
 		"user": {
-			"userId": ""
+			"userId": "test"
 		},
 		"new": true
 	},

--- a/test/fixtures/yesAfterGetPodcastIntent.json
+++ b/test/fixtures/yesAfterGetPodcastIntent.json
@@ -9,7 +9,7 @@
       "lastIntent": "GetPodcastIntent"
     },
     "user": {
-      "userId": ""
+      "userId": "test"
     },
     "new": false
   },

--- a/test/index.js
+++ b/test/index.js
@@ -96,7 +96,7 @@ tap.test('Test get headlines intent with a specific topic', test => {
     }
 );
 
-tap.test('Test the get opinion on sport intent', test => {
+tap.test('Test the get opinion', test => {
         test.plan(3);
         lambda(
             localizedOpinion, {

--- a/test/index.js
+++ b/test/index.js
@@ -21,7 +21,7 @@ const moreAfterLatestPodcast = require('./fixtures/moreAfterLatestPodcast.json')
 const posAfterLatestPodcast = require('./fixtures/posAfterLatestPodcast.json');
 const repeat = require('./fixtures/repeat.json');
 const topicAfterLaunch = require('./fixtures/topicAfterLaunch.json');
-
+const positionalContentAfterSportOpinion = require('./fixtures/positionalContentAfterSportOpinion.json');
 const speech = require('../src/speech').speech;
 
 var lambda = require('../src/index').handler;
@@ -141,6 +141,22 @@ tap.test('Test more intent after sport opinion', test => {
                     test.equal(response.sessionAttributes.moreOffset, 3);
                     test.equal(response.sessionAttributes.topic, 'sport');
                     test.equal(response.sessionAttributes.lastIntent, "GetOpinionIntent");
+                    test.end();
+                },
+                fail: function (error) {
+                    test.fail()
+                }
+            });
+    }
+);
+
+tap.test('Test positional content after sport opinion', test => {
+        test.plan(2);
+        lambda(
+            positionalContentAfterSportOpinion, {
+                succeed: function (response) {
+                    test.ok(response.response.outputSpeech.ssml.indexOf("written by") != -1);
+                    test.ok(response.response.outputSpeech.ssml.indexOf("minutes to read") != -1);
                     test.end();
                 },
                 fail: function (error) {


### PR DESCRIPTION
Stuff we're monitoring so far:

## In Ophan:

### Headlines to localized fronts
Capi query: `https://content.guardianapis.com/us?&api-key=test&show-fields=byline,headline&tag=type/article,-tone/minutebyminute,tone/news&show-editors-picks=true`

Url tracked: `https://www.theguardian.com/us`

### Headlines for a topic or a section
Capi query: `https://content.guardianapis.com/us-news/us-politics?&api-key=test&show-fields=byline,headline&tag=type/article,-tone/minutebyminute,tone/news&page-size=3&page=1`

Url tracked: `https://www.theguardian.com/us-news/us-politics`

### Localized opinions
Capi query: `https://content.guardianapis.com/us/commentisfree?&api-key=test&show-fields=byline,headline&tag=type/article,-tone/minutebyminute,tone/comment&page-size=3&page=1`

Url tracked: `https://www.theguardian.com/us/commentisfree`

### Sport opinion (topic)
Capi query: `https://content.guardianapis.com/us/sport?&api-key=test&show-fields=byline,headline&tag=type/article,-tone/minutebyminute,tone/comment&page-size=3&page=1`

Url tracked: `https://www.theguardian.com/us/sport`

### Reviews
Capi query: `https://content.guardianapis.com/search?api-key=test&page-size=3&page=1&tag=tone/reviews,film/film&show-fields=standfirst,byline,headline,star-rating&show-blocks=all`

Url tracked: `https://www.theguardian.com/film+tone/reviews`

## Console log:

Podcasts