### PR TITLE
Fix storing of podcast title in dynamo after playback begins

### DIFF
--- a/src/intentLogic/readContentAtPosition.js
+++ b/src/intentLogic/readContentAtPosition.js
@@ -21,9 +21,9 @@ module.exports = function () {
             .then(asJson)
             .then((json) => {
                 const podcastUrl = json.response.content.elements[0].assets[0].file;
-
                 if (podcastUrl) {
-                    const podcastDirective = helpers.getPodcastDirective(podcastUrl);
+                    const title = json.response.content.webTitle;
+                    const podcastDirective = helpers.getPodcastDirective(podcastUrl, title);
                     this.emit('PlayPodcastIntent', podcastDirective);
                 } else {
                     this.emit(':tell', speech.podcasts.notfound);

--- a/test/index.js
+++ b/test/index.js
@@ -355,7 +355,8 @@ tap.test('Test numeric position after latestPodcast', test => {
         lambda(
             posAfterLatestPodcast, {
                 succeed: function (response) {
-                  test.equal(response.response.directives[0].audioItem.stream.url, 'https://audio.guim.co.uk/2016/09/05-33499-gnl.books.20160903.st.simonrussellbeale.mp3')
+                    //token contains both the url and the title
+                    test.equal(response.response.directives[0].audioItem.stream.token, '{\"url\":\"https://audio.guim.co.uk/2016/09/05-33499-gnl.books.20160903.st.simonrussellbeale.mp3\",\"title\":\"Simon Russell-Beale reads from The Spy Who Came in from the Cold by John le Carré – books podcast\"}')
                     test.end()
                 },
                 fail: function (error) {


### PR DESCRIPTION
I've noticed an error in the lambda logs caused by this. It probably hasn't affected any users, but it can fail to write an update to s3 after playback of a podcast begins. This happens if you ask for "latest podcasts" rather than a specific podcast, and then say e.g. "second one"