### PR TITLE
Change in location of the config file and update in get-secrets.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ src/config.json
 .idea
 target
 *.iml
+npm-debug.log
+

--- a/bin/get-secrets.sh
+++ b/bin/get-secrets.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env node
+
 var AWS = require('aws-sdk');
+
+if( typeof process.env.TEAMCITY_BRANCH == "undefined"){
+    // Retreive the local CAPI credentials if not on teamcity
+    var credentials = new AWS.SharedIniFileCredentials({profile: 'capi'});
+    AWS.config.credentials = credentials;
+}
+
 var s3 = new AWS.S3();
 
 s3.getObject({

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "license": "Apache-2.0",
   "main": "src/index.js",
   "scripts": {
-    "presecrets": "mkdir -p tmp",
-    "secrets": "./bin/get-secrets.sh > tmp/config.json",
+    "presecrets": "mkdir -p conf",
+    "secrets": "./bin/get-secrets.sh > conf/config.json",
     "predeploy": "npm run secrets",
     "deploy": "gulp deploy",
     "pretest": "npm run secrets",

--- a/src/capiQueryBuilder.js
+++ b/src/capiQueryBuilder.js
@@ -1,4 +1,4 @@
-const config = require("../tmp/config.json");
+const config = require("../conf/config.json");
 const helpers = require('./helpers');
 
 const CAPI_API_KEY = config.capi_key;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,4 +1,4 @@
-const config = require("../tmp/config.json");
+const config = require("../conf/config.json");
 const CAPI_API_KEY = config.capi_key;
 const get = require('simple-get-promise').get;
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 // dependencies
 const get = require('simple-get-promise').get;
-const config = require('../tmp/config.json');
+const config = require('../conf/config.json');
 const Alexa = require('alexa-sdk');
 
 // config

--- a/src/intentLogic/getPodcast.js
+++ b/src/intentLogic/getPodcast.js
@@ -1,7 +1,7 @@
 const get = require('simple-get-promise').get;
 const asJson = require('simple-get-promise').asJson;
 
-const config = require("../../tmp/config.json");
+const config = require("../../conf/config.json");
 const CAPI_API_KEY = config.capi_key;
 const speech = require('../speech').speech;
 const capiQueryBuilder = require('../capiQueryBuilder');

--- a/src/intentLogic/latestPodcast.js
+++ b/src/intentLogic/latestPodcast.js
@@ -1,7 +1,7 @@
 const get = require('simple-get-promise').get;
 const asJson = require('simple-get-promise').asJson;
 
-const config = require("../../tmp/config.json");
+const config = require("../../conf/config.json");
 const CAPI_API_KEY = config.capi_key;
 const BASE_URL = "https://content.guardianapis.com/";
 const speech = require('../speech').speech;

--- a/src/intentLogic/readContentAtPosition.js
+++ b/src/intentLogic/readContentAtPosition.js
@@ -7,7 +7,7 @@ const helpers = require('../helpers');
 const speech = require('../speech').speech;
 const sound = require('../speech').sound;
 const randomMsg = require('../helpers').randomMessage;
-const config = require("../../tmp/config.json");
+const config = require("../../conf/config.json");
 const CAPI_API_KEY = config.capi_key;
 const hitOphan = require('../helpers').hitOphanEndpoint;
 


### PR DESCRIPTION
Change in location of the config file and update in get-secrets.sh

1. Changes the location of the config file from
tmp/config.json to `conf/config.json`. The instructions related
to config.json and config.json.sample will be given in the
README file (see separate branch).

2. We no longer need to set our own developers CAPI keys in the config file.
The script get-secrets.sh has been updated to generate the config file from
the one in the `alexa-config` bucket. For this, correct JANUS credentials
need to be available locally as they are used to access the bucket.

To detect whether we are on local or being deployed on TeamCity, the code
tests the TEAMCITY_BRANCH environment variable.