### PR TITLE
Filter out long articles

### DIFF
--- a/src/capiQueryBuilder.js
+++ b/src/capiQueryBuilder.js
@@ -24,7 +24,8 @@ exports.newsQuery = (offset, locale, topic) => {
     if (props !== null) {
         return BASE_URL + props.path + "?"
             + "&api-key=" + CAPI_API_KEY
-            + "&show-fields=byline,headline"
+            + "&show-fields=byline,headline,charCount"
+            + "&max-char-count="+ helpers.maxCharCount
             + "&tag=type/article,-tone/minutebyminute"
             + (props.toneNews ? ",tone/news" : "")
             + (props.editorsPicks ? "&show-editors-picks=true" : getPageParams(offset))
@@ -51,6 +52,7 @@ exports.opinionQuery = (offset, locale, topic) => {
         return BASE_URL + props.path + "?"
             + "&api-key=" + CAPI_API_KEY
             + "&show-fields=byline,headline"
+            + "&max-char-count="+ helpers.maxCharCount
             + "&tag=type/article,-tone/minutebyminute"
             + ",tone/comment"
             + getPageParams(offset);
@@ -67,6 +69,7 @@ exports.reviewQuery = (offset, reviewType) => {
             + "?api-key=" + CAPI_API_KEY
             + getPageParams(offset)
             + "&tag=tone/reviews,"+ tagType
+            + "&max-char-count="+ helpers.maxCharCount
             + "&show-fields=standfirst,byline,headline,star-rating&show-blocks=all";
     } else {
         console.log(`reviewQuery: invalid review_type: ${reviewType}`);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -44,6 +44,17 @@ exports.getSectionPath = (section, edition) => {
     return edition +"/"+ section;
 };
 
+/**
+ * - amazonMaxChars: Amazon's char-limit for the outputSpeech field.
+ * - extraChars: Extra chars added at start/end of the article, including byline for which we generously allow 100 chars.
+ *
+ * e.g. -
+ *  "<speak> Absolutely, This article is written by Larry Elliott in Washington and it will take roughly 3 minutes to read.<break strength='x-strong'/> ...article body... <break strength='medium'/>Would you like to hear them again, or hear more headlines? </speak>"
+ */
+const amazonMaxChars = 8000;
+const extraChars = 315;
+exports.maxCharCount = amazonMaxChars - extraChars;
+
 const PAGE_SIZE = 3;
 exports.pageSize = PAGE_SIZE;
 

--- a/src/intentLogic/getHeadlines.js
+++ b/src/intentLogic/getHeadlines.js
@@ -11,6 +11,7 @@ const getTopic = require('../helpers').getTopic;
 const capiQueryBuilder = require('../capiQueryBuilder');
 const hitOphan = require('../helpers').hitOphanEndpoint;
 const localizeEdition = require('../helpers').localizeEdition;
+const maxCharCount = require('../helpers').maxCharCount;
 
 module.exports = function () {
 
@@ -65,8 +66,10 @@ const notFoundMessage = (topic) => {
  */
 const getResults = (json, moreOffset) => {
     if (json.response.editorsPicks) {
-        if (json.response.editorsPicks.length >= moreOffset) {
-            return json.response.editorsPicks.slice(moreOffset, moreOffset+3);
+        //We have to manually filter out long articles when we use editors-picks
+        const filteredPicks = json.response.editorsPicks.filter(pick => pick.fields.charCount && pick.fields.charCount < maxCharCount);
+        if (filteredPicks.length >= moreOffset) {
+            return filteredPicks.slice(moreOffset, moreOffset+3);
         } else {
             return null;
         }

--- a/src/intentLogic/readContentAtPosition.js
+++ b/src/intentLogic/readContentAtPosition.js
@@ -32,7 +32,7 @@ module.exports = function () {
     };
 
     const readArticle = (contentId) => {
-        const capiQuery = helpers.capiQuery(contentId, '&show-fields=body,byline,wordcount');
+        const capiQuery = helpers.capiQuery(contentId, '&show-fields=body,bodyText,byline,wordcount');
         get(capiQuery)
             .then(asJson)
             .then((json) => {
@@ -79,8 +79,13 @@ module.exports = function () {
 
 };
 
+const getBody = (json) => {
+    if (json.response.content.fields.bodyText) return json.response.content.fields.bodyText;
+    else return striptags(json.response.content.fields.body);   //body field may contain html tags
+};
+
 const getArticle = (json) => {
-    var articleBody = xmlescape(striptags(json.response.content.fields.body));
+    var articleBody = xmlescape(getBody(json));
 
     return randomMsg(speech.acknowledgement) +
         speech.positionalContent.articleBy + json.response.content.fields.byline +


### PR DESCRIPTION
Amazon imposes a limit of 8000 chars. We can now get capi to filter using max-char-count.
Where we use editors-picks, we have to manually filter out results based on their charCount.
We now use the bodyText field, which has no html.