### PR TITLE
If user asks for a podcast again from within the skill, resume

### DIFF
--- a/src/intentLogic/readContentAtPosition.js
+++ b/src/intentLogic/readContentAtPosition.js
@@ -20,9 +20,7 @@ module.exports = function () {
       .then((json) => {
         const podcastUrl = json.response.content.elements[0].assets[0].file
         if (podcastUrl) {
-          const title = json.response.content.webTitle
-          const podcastDirective = helpers.getPodcastDirective(podcastUrl, title)
-          this.emit('PlayPodcastIntent', podcastDirective)
+          helpers.playPodcast.call(this, podcastUrl, json.response.content.webTitle)
         } else {
           this.emit(':tell', speech.podcasts.notfound)
         }

--- a/src/intentLogic/yes.js
+++ b/src/intentLogic/yes.js
@@ -1,18 +1,14 @@
-// const get = require('simple-get-promise').get
-// const asJson = require('simple-get-promise').asJson
 const helpers = require('../helpers')
 const speech = require('../speech').speech
-// const sound = require('../speech').sound
 
 module.exports = function () {
   const attributes = this.event.session.attributes
 
   switch (attributes.lastIntent) {
     case 'GetPodcastIntent':
-      const podcastDirective = helpers.getPodcastDirective(attributes.podcastUrl, attributes.podcastTitle)
-      console.log('Playing podcast ' + attributes.podcastUrl)
-      this.emit('PlayPodcastIntent', podcastDirective)
+      helpers.playPodcast.call(this, attributes.podcastUrl, attributes.podcastTitle)
       break
+
     case 'GetHeadlinesIntent':
     case 'GetOpinionIntent':
       // Assume the user has just been asked if they'd like the list of topics

--- a/src/userStore.js
+++ b/src/userStore.js
@@ -60,3 +60,22 @@ UserStore.prototype.setAudio = function (id, url, title, offset, callback) {
     }
   }, callback)
 }
+
+//If the user last listened to the podcast at url, return the milliseconds offset
+UserStore.prototype.getAudioOffset = function(id, url, callback) {
+  this._docClient.get({
+    TableName: this._tableName,
+    Key: {
+      'userId': id
+    }
+  }, (err, data) => {
+    const offset = getPodcastOffset(data, url)
+    callback(offset)
+  })
+}
+
+const getPodcastOffset = (data, url) => {
+  if (data && data.Item && data.Item.podcastOffset && data.Item.podcastUrl == url) {
+    return data.Item.podcastOffset
+  } else return 0
+}


### PR DESCRIPTION
Previously, you could only resume a podcast by saying "resume" from outside the skill.
Now, if you previously paused Football Weekly then return to the Guardian skill and ask to play Football Weekly, it resumes rather than starting again.